### PR TITLE
Throw exception if any error is encountered

### DIFF
--- a/bin/swagger
+++ b/bin/swagger
@@ -138,11 +138,12 @@ set_exception_handler(function ($exception) {
     exit($exception->getCode() ?: 1);
 });
 \Swagger\Logger::getInstance()->log = function ($entry, $type) {
-    $type = $type === E_USER_NOTICE ? 'INFO' : 'WARN';
+
     if ($entry instanceof Exception) {
         $entry = $entry->getMessage();
     }
-    error_log('[' . $type . '] ' . $entry . PHP_EOL);
+
+    throw new Exception('Swagger Schema Not Valid: '. $entry . PHP_EOL);
 };
 
 


### PR DESCRIPTION
Throw on error to fail on singularity if swagger annotations are incorrect

Output example: 
![image](https://cloud.githubusercontent.com/assets/1131348/18326308/226e19d6-7513-11e6-9808-de85d8757ad6.png)